### PR TITLE
Upgrade NetBox v4.4.7 → v4.5.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
-FROM ghcr.io/netbox-community/netbox:v4.4.7
-
-ENV LANG=C.utf8 \
-    PATH=/opt/netbox/venv/bin:$PATH \
-    TOPOLOGY_STATIC=/opt/netbox/netbox/static/netbox_topology_views
+FROM ghcr.io/netbox-community/netbox:v4.5.6
 
 COPY configuration/plugins.py /etc/netbox/config/plugins.py
 COPY configuration/extra.py /etc/netbox/config/extra.py
@@ -11,15 +7,12 @@ COPY configuration/logging.py /etc/netbox/config/logging.py
 COPY configuration/local_settings.py /opt/netbox/netbox/netbox/local_settings.py
 COPY authentication/custom_pipeline.py /opt/netbox/netbox/netbox/custom_pipeline.py
 COPY requirements.txt /tmp/requirements.txt
-COPY entrypoint.sh /opt/netbox/entrypoint.sh
 
 RUN /usr/local/bin/uv pip install -r /tmp/requirements.txt && \
-    mkdir -p $TOPOLOGY_STATIC/img && chown unit:root -R $TOPOLOGY_STATIC && \
-    mkdir -p /opt/netbox/netbox/static/debug_toolbar && chown unit:root /opt/netbox/netbox/static/debug_toolbar && \
-    chown unit:root /opt/netbox/entrypoint.sh; chmod +x /opt/netbox/entrypoint.sh && \
-    sed -i 's/OpenID Connect/NexGen Cloud Login/g' /opt/netbox/netbox/netbox/authentication/__init__.py && \
-    rm -rf /tmp/requirements.txt
+    SECRET_KEY="build-only-dummy-key-not-used-at-runtime-minimum-50-chars" \
+      python manage.py collectstatic --no-input && \
+    sed -i 's/OpenID Connect/NexGen Cloud Login/g' \
+      /opt/netbox/netbox/netbox/authentication/__init__.py && \
+    rm -f /tmp/requirements.txt
 
-ENTRYPOINT [ "/usr/bin/tini", "--" ]
-
-CMD [ "/opt/netbox/entrypoint.sh" ]
+CMD [ "/opt/netbox/docker-entrypoint.sh", "/opt/netbox/launch-netbox.sh" ]

--- a/authentication/custom_pipeline.py
+++ b/authentication/custom_pipeline.py
@@ -1,42 +1,23 @@
 from netbox.authentication import Group
 
-class AuthFailed(Exception):
-    pass
 
-def add_groups(response, user, backend, *args, **kwargs):
-    try:
-        groups = response['groups']
-    except KeyError:
-        pass
-
-    for group in groups:
-        group, created = Group.objects.get_or_create(name=group)
-        user.groups.add(group)
-
-def remove_groups(response, user, backend, *args, **kwargs):
-    try:
-        groups = response['groups']
-    except KeyError:
+def sync_groups(response, user, backend, *args, **kwargs):
+    """Sync user's NetBox groups to match the OIDC provider response."""
+    groups = response.get('groups')
+    if groups is None:
         user.groups.clear()
-        pass
+        return
 
-    user_groups = [item.name for item in user.groups.all()]
-    delete_groups = list(set(user_groups) - set(groups))
+    # Ensure all OIDC groups exist in NetBox
+    for group_name in groups:
+        Group.objects.get_or_create(name=group_name)
 
-    for delete_group in delete_groups:
-        group = Group.objects.get(name=delete_group)
-        user.groups.remove(group)
+    # Atomically set user's groups to exactly match the OIDC response
+    user.groups.set(Group.objects.filter(name__in=groups))
 
 
 def set_roles(response, user, backend, *args, **kwargs):
-    user.is_superuser = False
-    user.is_staff = False
-    try:
-        groups = response['groups']
-    except KeyError:
-        user.save()
-        pass
-
-    user.is_superuser = True if 'superusers' in groups else False
-    user.is_staff = True if 'staff' in groups else False
+    """Set superuser flag based on OIDC group membership."""
+    groups = response.get('groups', [])
+    user.is_superuser = 'superusers' in groups
     user.save()

--- a/configuration/ngcauth.py
+++ b/configuration/ngcauth.py
@@ -4,7 +4,7 @@ SOCIAL_AUTH_OIDC_ENDPOINT = environ.get('SOCIAL_AUTH_OIDC_ENDPOINT')
 SOCIAL_AUTH_OIDC_KEY = environ.get('SOCIAL_AUTH_OIDC_KEY')
 SOCIAL_AUTH_OIDC_SECRET = environ.get('SOCIAL_AUTH_OIDC_SECRET')
 LOGOUT_REDIRECT_URL = environ.get('LOGOUT_REDIRECT_URL')
-SOCIAL_AUTH_OIDC_SCOPE=["openid", "profile", "email", "roles"]
+SOCIAL_AUTH_OIDC_SCOPE = ["openid", "profile", "email", "roles"]
 
 SOCIAL_AUTH_PIPELINE = (
     'social_core.pipeline.social_auth.social_details',
@@ -15,7 +15,6 @@ SOCIAL_AUTH_PIPELINE = (
     'social_core.pipeline.social_auth.associate_user',
     'social_core.pipeline.social_auth.load_extra_data',
     'social_core.pipeline.user.user_details',
-    'netbox.custom_pipeline.add_groups',
-    'netbox.custom_pipeline.remove_groups',
-    'netbox.custom_pipeline.set_roles'
+    'netbox.custom_pipeline.sync_groups',
+    'netbox.custom_pipeline.set_roles',
 )

--- a/configuration/ngcauth.py
+++ b/configuration/ngcauth.py
@@ -1,9 +1,15 @@
 from os import environ
 
-SOCIAL_AUTH_OIDC_ENDPOINT = environ.get('SOCIAL_AUTH_OIDC_ENDPOINT')
-SOCIAL_AUTH_OIDC_KEY = environ.get('SOCIAL_AUTH_OIDC_KEY')
-SOCIAL_AUTH_OIDC_SECRET = environ.get('SOCIAL_AUTH_OIDC_SECRET')
-LOGOUT_REDIRECT_URL = environ.get('LOGOUT_REDIRECT_URL')
+# Upstream configuration.py now reads all OIDC env vars natively
+# (SOCIAL_AUTH_OIDC_OIDC_ENDPOINT, SOCIAL_AUTH_OIDC_KEY, SOCIAL_AUTH_OIDC_SECRET,
+# LOGOUT_REDIRECT_URL, REMOTE_AUTH_BACKEND, REMOTE_AUTH_ENABLED).
+#
+# We only override:
+# 1. SOCIAL_AUTH_OIDC_SCOPE — upstream parses it as space-separated string,
+#    but we need 'roles' scope for authentik group sync which the env var handles.
+#    This Python list takes priority over the upstream's _AS_LIST parsing.
+# 2. SOCIAL_AUTH_PIPELINE — to include our custom group sync and role mapping.
+
 SOCIAL_AUTH_OIDC_SCOPE = ["openid", "profile", "email", "roles"]
 
 SOCIAL_AUTH_PIPELINE = (

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,4 @@
 ---
-version: '3.4'
-
 services:
 
   netbox:
@@ -12,9 +10,9 @@ services:
       - redis
       - redis-cache
     env_file: env/netbox.env
-    user: 'unit:root'
+    user: 'netbox:root'
     healthcheck:
-      start_period: 90s
+      start_period: 600s
       timeout: 3s
       interval: 15s
       test: curl -f http://localhost:8080/login/ || exit 1
@@ -28,7 +26,7 @@ services:
   netbox-worker:
     build: ./
     env_file: env/netbox.env
-    user: 'unit:root'
+    user: 'netbox:root'
     depends_on:
       netbox:
         condition: service_healthy

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-/opt/netbox/venv/bin/python manage.py migrate
-/opt/netbox/venv/bin/python manage.py collectstatic --no-input
-/opt/netbox/docker-entrypoint.sh /opt/netbox/launch-netbox.sh

--- a/env/netbox.env.sample
+++ b/env/netbox.env.sample
@@ -1,7 +1,8 @@
+API_TOKEN_PEPPER_1=change-me-to-a-random-secret-minimum-50-chars-long!!
 CORS_ORIGIN_ALLOW_ALL=True
 DB_HOST=postgres
 DB_NAME=netbox
-DB_PASSWORD='yRNllhz6U26BVDtd'
+DB_PASSWORD=changeme
 DB_USER=netbox
 EMAIL_FROM=netbox@bar.com
 EMAIL_PASSWORD=
@@ -14,21 +15,23 @@ EMAIL_USERNAME=netbox
 # EMAIL_USE_SSL and EMAIL_USE_TLS are mutually exclusive, i.e. they can't both be `true`!
 EMAIL_USE_SSL=false
 EMAIL_USE_TLS=false
+GRANIAN_BACKPRESSURE=4
+GRANIAN_WORKERS=4
 GRAPHQL_ENABLED=true
 MEDIA_ROOT=/opt/netbox/netbox/media
 METRICS_ENABLED=false
 REDIS_CACHE_DATABASE=1
 REDIS_CACHE_HOST=redis-cache
 REDIS_CACHE_INSECURE_SKIP_TLS_VERIFY=false
-REDIS_CACHE_PASSWORD='Lo3SfPsP5cHXQqm6'
+REDIS_CACHE_PASSWORD=changeme
 REDIS_CACHE_SSL=false
 REDIS_DATABASE=0
 REDIS_HOST=redis
 REDIS_INSECURE_SKIP_TLS_VERIFY=false
-REDIS_PASSWORD='FGEey766SJYi6MK7'
+REDIS_PASSWORD=changeme
 REDIS_SSL=false
 RELEASE_CHECK_URL=https://api.github.com/repos/netbox-community/netbox/releases
-SECRET_KEY='9wUbsED!kSj$KyvoKj&AU2nJNK^jBU^gNGtJl7gbYV2&o@dGqGbdU96AbfxN'
+SECRET_KEY='r(m)9nLGnz$(_q3N4z1k(EFsMCjjjzx08x9VhNVcfd%6RF#r!6DE@+V5Zk2X'
 SKIP_SUPERUSER=true
 WEBHOOKS_ENABLED=true
 CACHE_TIMEOUT=0
@@ -38,11 +41,10 @@ DEBUG=False
 LOGLEVEL=INFO
 
 # Auth
-# ALLOW_TOKEN_RETRIEVAL defaults to false in NetBox v4.3+. Set to true if you need to retrieve existing tokens via API/UI.
-# ALLOW_TOKEN_RETRIEVAL=true
-REMOTE_AUTH_ENABLED='true'
-REMOTE_AUTH_BACKEND='social_core.backends.open_id_connect.OpenIdConnectAuth'
-SOCIAL_AUTH_OIDC_ENDPOINT='https://endpoint.com/application/o/<Application slug>/'
-SOCIAL_AUTH_OIDC_KEY=''
-SOCIAL_AUTH_OIDC_SECRET=''
-LOGOUT_REDIRECT_URL='https://endpoint.com/application/o/<Application slug>/end-session/'
+REMOTE_AUTH_ENABLED=true
+REMOTE_AUTH_BACKEND=social_core.backends.open_id_connect.OpenIdConnectAuth
+SOCIAL_AUTH_OIDC_OIDC_ENDPOINT=https://auth.example.com/application/o/netbox-slug/
+SOCIAL_AUTH_OIDC_KEY=your-client-id
+SOCIAL_AUTH_OIDC_SECRET=your-client-secret
+SOCIAL_AUTH_OIDC_SCOPE=openid profile email roles
+LOGOUT_REDIRECT_URL=https://auth.example.com/application/o/netbox-slug/end-session/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 social-auth-core[openidconnect]
-netbox-bgp==0.17.0
-netbox-topology-views==4.4.0
-netboxlabs-netbox-branching==0.7.2
-python-jose
+netbox-bgp==0.18.1
+netbox-topology-views==4.5.1
+netboxlabs-netbox-branching==0.8.3


### PR DESCRIPTION
  ## Summary

  Upgrades the NetBox container from v4.4.7 to v4.5.6, with all plugin version bumps, auth pipeline fixes,
  and alignment with upstream netbox-docker 4.0.x conventions.

  **Breaking change for deployment:** The OIDC endpoint env var has been renamed from
  `SOCIAL_AUTH_OIDC_ENDPOINT` to `SOCIAL_AUTH_OIDC_OIDC_ENDPOINT` (double OIDC) to match the upstream
  netbox-docker convention. This must be updated in the Kubernetes secrets before deploying.

  ### Changes

  - **Base image** `v4.4.7` → `v4.5.6` (Python 3.12+, Django 5.2, Granian web server)
  - **Container user** `unit` → `netbox` (Dockerfile + docker-compose)
  - **Plugins** bumped for v4.5.x compatibility:
    - `netbox-bgp` 0.17.0 → 0.18.1
    - `netbox-topology-views` 4.4.0 → 4.5.1
    - `netboxlabs-netbox-branching` 0.7.2 → 0.8.3
  - **Auth pipeline rewrite** (`custom_pipeline.py`):
    - Merged `add_groups()` + `remove_groups()` into single `sync_groups()` using Django's `set()`
    - Fixed 3 latent `UnboundLocalError` bugs (broken `except KeyError: pass` pattern)
    - Removed `is_staff` field usage (deleted from NetBox User model in v4.5.0)
  - **OIDC config** (`ngcauth.py`): stripped down to only scope + pipeline overrides; upstream
  `configuration.py` now handles all OIDC env vars natively
  - **Env sample** aligned with upstream: renamed OIDC endpoint var, removed quotes from bool/list values,
  added `API_TOKEN_PEPPER_1`, `GRANIAN_WORKERS`, `GRANIAN_BACKPRESSURE`
  - **Dockerfile** simplified: proper `collectstatic` at build time, removed redundant ENV/mkdir/chown,
  removed dead debug_toolbar dir
  - **Deleted `entrypoint.sh`**: upstream `docker-entrypoint.sh` handles migrations, static files, and
  post-migration cleanup
  - **Removed `python-jose`** from requirements (orphaned dep)