### PR TITLE
Add netbox-floorplan and netbox-reorder-rack plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ vendor/pkg/
 pyenv
 Vagrantfile
 *.env
+# Local DB dumps / scratch (prod data — do not commit)
+tmp/
+*.sql
+.serena/

--- a/configuration/plugins.py
+++ b/configuration/plugins.py
@@ -1,6 +1,8 @@
 PLUGINS = [
     'netbox_bgp',
     'netbox_topology_views',
+    'netbox_reorder_rack',
+    'netbox_floorplan',
     # Must be last plugin - https://github.com/netboxlabs/netbox-branching?tab=readme-ov-file#installation
     'netbox_branching'
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 social-auth-core[openidconnect]
 netbox-bgp==0.18.1
 netbox-topology-views==4.5.1
+netbox-reorder-rack==1.1.4
+netbox-floorplan-plugin==0.9.1
 netboxlabs-netbox-branching==1.0.2


### PR DESCRIPTION
  Adds two DCIM plugins to the NetBox v4.5.10 image:

  - **netbox-floorplan-plugin** `0.9.1` — draw site/location floorplans, place racks/devices, SVG export
  - **netbox-reorder-rack** `1.1.4` — drag-to-reorder devices within a rack

  ### Changes
  - `requirements.txt` — pin both plugins (no transitive deps)
  - `configuration/plugins.py` — register modules before `netbox_branching` (must stay last)
  - `.gitignore` — ignore local DB dumps / scratch (`tmp/`, `*.sql`, `.serena/`)

  ### Compatibility (verified)
  - floorplan `0.9.1` → NetBox 4.5.x (`min 4.5.0` / `max 4.5.99`). **Do not bump to 0.9.2** — it's 4.6.x-only.
  - reorder-rack `1.1.4` → no version cap, loads on 4.5.10. Latest release.